### PR TITLE
improve shell scripts

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,16 +1,18 @@
 #!/bin/sh
 
+PORT="${1:-6379}"
+
 # Get the SHA1 hash for our scripts by simply generating an error and
 # filtering out the hash.
-add=`redis-cli --eval add.lua | sed 's/.*f_\([0-9a-z]\{40\}\).*/\1/'`
-check=`redis-cli --eval check.lua | sed 's/.*f_\([0-9a-z]\{40\}\).*/\1/'`
+add=$(redis-cli -p "$PORT" --eval add.lua | sed 's/.*f_\([0-9a-z]\{40\}\).*/\1/')
+check=$(redis-cli -p "$PORT" --eval check.lua | sed 's/.*f_\([0-9a-z]\{40\}\).*/\1/')
 
 # Find a free key to use.
 # 10 characters should be enough to find a free key quickly.
 while true; do
-  key=`LC_ALL=C tr -dc "[:alnum:]" < /dev/urandom | head -c 10`
+  key=$(LC_ALL=C tr -dc "[:alnum:]" < /dev/urandom | head -c 10)
 
-  if [ -z `echo "keys $key:*" | redis-cli --raw` ]; then
+  if [ -z "$(echo "keys $key:*" | redis-cli -p "$PORT" --raw)" ]; then
     break
   fi
 done
@@ -20,14 +22,14 @@ args="0 $key 1000000 0.01 :rand:000000000000"
 iter=200000
 
 echo add.lua
-redis-benchmark -c 20 -n $iter -r 2000000000 evalsha $add $args
+redis-benchmark -p "$PORT" -c 20 -n $iter -r 2000000000 evalsha "$add" "$args"
 
 echo check.lua
-redis-benchmark -c 20 -n $iter -r 2000000000 evalsha $check $args
+redis-benchmark -p "$PORT" -c 20 -n $iter -r 2000000000 evalsha "$check" "$args"
 
 
 # Delete all the keys we used.
-for k in `echo "keys $key:*" | redis-cli --raw`; do
-  echo "del $k" | redis-cli > /dev/null
+for k in $(echo "keys $key:*" | redis-cli -p "$PORT" --raw); do
+  echo "del $k" | redis-cli -p "$PORT" > /dev/null
 done
 

--- a/layer-benchmark.sh
+++ b/layer-benchmark.sh
@@ -1,16 +1,18 @@
 #!/bin/sh
 
+PORT="${1:-6379}"
+
 # Get the SHA1 hash for our scripts by simply generating an error and
 # filtering out the hash.
-add=`redis-cli --eval layer-add.lua | sed 's/.*f_\([0-9a-z]\{40\}\).*/\1/'`
-check=`redis-cli --eval layer-check.lua | sed 's/.*f_\([0-9a-z]\{40\}\).*/\1/'`
+add=$(redis-cli -p "$PORT" --eval layer-add.lua | sed 's/.*f_\([0-9a-z]\{40\}\).*/\1/')
+check=$(redis-cli -p "$PORT" --eval layer-check.lua | sed 's/.*f_\([0-9a-z]\{40\}\).*/\1/')
 
 # Find a free key to use.
 # 10 characters should be enough to find a free key quickly.
 while true; do
-  key=`LC_ALL=C tr -dc "[:alnum:]" < /dev/urandom | head -c 10`
+  key=$(LC_ALL=C tr -dc "[:alnum:]" < /dev/urandom | head -c 10)
 
-  if [ -z `echo "keys $key:*" | redis-cli --raw` ]; then
+  if [ -z "$(echo "keys $key:*" | redis-cli -p "$PORT" --raw)" ]; then
     break
   fi
 done
@@ -20,14 +22,14 @@ args="0 $key 1000000 0.01 :rand:000000000000"
 iter=20000
 
 echo layer-add.lua
-redis-benchmark -c 20 -n $iter -r 2000000000 evalsha $add $args
+redis-benchmark -p "$PORT" -c 20 -n $iter -r 2000000000 evalsha "$add" "$args"
 
 echo layer-check.lua
-redis-benchmark -c 20 -n $iter -r 2000000000 evalsha $check $args
+redis-benchmark -p "$PORT" -c 20 -n $iter -r 2000000000 evalsha "$check" "$args"
 
 
 # Delete all the keys we used.
-for k in `echo "keys $key:*" | redis-cli --raw`; do
-  echo "del $k" | redis-cli > /dev/null
+for k in $(echo "keys $key:*" | redis-cli -p "$PORT" --raw); do
+  echo "del $k" | redis-cli -p "$PORT" > /dev/null
 done
 


### PR DESCRIPTION
While I was using your scripts to test a redis-compliant database on its lua scripting capabilities, I noticed that your scripts would fail in weird ways, when the database returns errors. So I was checking your scripts and noticed a couple of things that could be done better in the shell scripts according to my knowledge and the standards. I also added the option to define another port (as the first argument), as this might be useful for people who aren't running redis on the default port (as I wasn't). For people who were relying on the default port, it will keep working, as it remains the default.